### PR TITLE
Fix crashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches: [smartlyio]
-  pull-request:
+  pull_request:
     branches: [smartlyio]
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   push:
     branches: [smartlyio]
+  pull-request:
+    branches: [smartlyio]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,44 +2,18 @@ name: Release
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches: [smartlyio]
 
 jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
         with:
-          go-version: '1.16'
-
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Build
-        run: CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-X 'main.version=${{ steps.get_version.outputs.VERSION }}'" -o github-actions-exporter
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: github-actions-exporter
-          asset_name: github-actions-exporter
-          asset_content_type: application/binary
+          tags: |
+            github-actions-exporter:${{ github.sha }}
+          build-args: |
+            VERSION=${{ github.sha }}
+          push: false

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.16 as builder
 
+ARG VERSION=
+ENV VERSION=$VERSION
+
 WORKDIR /app
 COPY . .
 RUN bash ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,4 @@
 
 set -x
 
-VERSION=`git branch | grep '*' | awk '{print $2}'`
-if [[ $VERSION == "master" ]];
-then
-  VERSION=`git describe --tags --abbrev=0`
-fi
-
 CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-X 'main.version=$VERSION'"  -o bin/app

--- a/pkg/metrics/get_runners_organization_from_github.go
+++ b/pkg/metrics/get_runners_organization_from_github.go
@@ -30,6 +30,7 @@ func getRunnersOrganizationFromGithub() {
 				resp, rr, err := client.Actions.ListOrganizationRunners(context.Background(), orga, opt)
 				if err != nil {
 					log.Printf("ListOrganizationRunners error for %s: %s", orga, err.Error())
+					break
 				} else {
 					for _, runner := range resp.Runners {
 						if runner.GetStatus() == "online" {

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -29,7 +29,7 @@ func getFieldValue(repo string, run github.WorkflowRun, field string) string {
 	case "workflow_id":
 		return strconv.FormatInt(*run.WorkflowID, 10)
 	case "workflow":
-		return *workflows[repo][*run.WorkflowID].Name
+		return *run.Name
 	case "event":
 		return *run.Event
 	case "status":


### PR DESCRIPTION
1. Fix API abuse of GitHub by breaking busy-loop hitting API on errors
2. Fix crash dereferencing null workflow by using the workflow name directly available in the workflow run
3. Remove build pipeline for replacing later