### PR TITLE
Quick and dirty workflow job stats

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,12 +12,13 @@ var (
 		Refresh           int64
 		Repositories      cli.StringSlice
 		Organizations     cli.StringSlice
-		APIURL            string			
+		APIURL            string
 	}
 	Port  int
 	Debug bool
 	EnterpriseName    string
 	WorkflowFields    string
+	JobFields          string
 )
 
 // InitConfiguration - set configuration from env vars or command parameters
@@ -108,6 +109,13 @@ func InitConfiguration() []cli.Flag {
 			Usage:       "A comma separated list of fields for workflow metrics that should be exported",
 			Value:       "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status",
 			Destination: &WorkflowFields,
+		},
+		&cli.StringFlag{
+			Name:        "export_job_fields",
+			EnvVars:     []string{"EXPORT_JOB_FIELDS"},
+			Usage:       "A comma separated list of fields for workflow job metrics that should be exported",
+			Value:       "repo,id,name,node_id,head_branch,head_sha,run_id,workflow_id,workflow,status,conclusion,runner_id,runner_name",
+			Destination: &JobFields,
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ func InitConfiguration() []cli.Flag {
 			Name:        "export_job_fields",
 			EnvVars:     []string{"EXPORT_JOB_FIELDS"},
 			Usage:       "A comma separated list of fields for workflow job metrics that should be exported",
-			Value:       "repo,id,name,node_id,head_branch,head_sha,run_id,workflow_id,workflow,status,conclusion,runner_id,runner_name",
+			Value:       "repo,id,name,node_id,head_branch,head_sha,run_id,workflow_id,workflow,status,conclusion",
 			Destination: &JobFields,
 		},
 	}

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -68,10 +68,10 @@ func getRelevantJobFields(repo string, run *github.WorkflowRun, job *github.Work
 			result[i] = *job.Status
 			case "conclusion":
 			result[i] = *job.Conclusion
-			case "runner_id":
-			result[i] = strconv.FormatInt(*job.RunnerID, 10)
-			case "runner_name":
-			result[i] = *job.RunnerName
+			// case "runner_id":
+			// result[i] = strconv.FormatInt(*job.RunnerID, 10)
+			// case "runner_name":
+			// result[i] = *job.RunnerName
 			default:
 			result[i] = getFieldValue(repo, *run, field)
 		}

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -54,10 +54,8 @@ func getRelevantJobFields(repo string, run *github.WorkflowRun, job *github.Work
 	result := make([]string, len(relevantFields))
 	for i, field := range relevantFields {
 		switch field {
-			case "run_id":
-			result[i] = strconv.FormatInt(*job.ID, 10)
 			case "id":
-			result[i] = strconv.FormatInt(*run.ID, 10)
+			result[i] = strconv.FormatInt(*job.ID, 10)
 			case "name":
 			result[i] = *job.Name
 			case "node_id":
@@ -72,6 +70,8 @@ func getRelevantJobFields(repo string, run *github.WorkflowRun, job *github.Work
 			// result[i] = strconv.FormatInt(*job.RunnerID, 10)
 			// case "runner_name":
 			// result[i] = *job.RunnerName
+			case "run_id":
+			result[i] = strconv.FormatInt(*run.ID, 10)
 			default:
 			result[i] = getFieldValue(repo, *run, field)
 		}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,10 +38,18 @@ func InitMetrics() {
 		},
 		strings.Split(config.WorkflowFields, ","),
 	)
+	workflowRunJobDurationGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_workflow_run_job_duration_ms",
+			Help: "Workflow run job duration (in milliseconds)",
+		},
+		strings.Split(config.JobFields, ","),
+	)
 	prometheus.MustRegister(runnersGauge)
 	prometheus.MustRegister(runnersOrganizationGauge)
 	prometheus.MustRegister(workflowRunStatusGauge)
 	prometheus.MustRegister(workflowRunDurationGauge)
+	prometheus.MustRegister(workflowRunJobDurationGauge)
 	prometheus.MustRegister(workflowBillGauge)
 	prometheus.MustRegister(runnersEnterpriseGauge)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	client                   *github.Client
-	err                      error
-	workflowRunStatusGauge   *prometheus.GaugeVec
-	workflowRunDurationGauge *prometheus.GaugeVec
+	client                      *github.Client
+	err                         error
+	workflowRunStatusGauge      *prometheus.GaugeVec
+	workflowRunDurationGauge    *prometheus.GaugeVec
+	workflowRunJobDurationGauge *prometheus.GaugeVec
 )
 
 // InitMetrics - register metrics in prometheus lib and start func for monitor


### PR DESCRIPTION
Add a quick and dirty export of workflow job-level metrics.

Adds the gauges like the following:

```
# HELP github_workflow_run_job_duration_ms Workflow run job duration (in milliseconds)
# TYPE github_workflow_run_job_duration_ms gauge
github_workflow_run_job_duration_ms{conclusion="success",head_branch="fix-crashes",head_sha="4b09ded20eee787d9f05fb3d7d37c1ca28b2d5bc",id="6655836885",name="Upload Release Asset",node_id="CR_kwDOHa4RRM8AAAABjLgC1Q",repo="smartlyio/github-actions-exporter",run_id="2409395935",status="completed",workflow="Build",workflow_id="27134893"} 62000
github_workflow_run_job_duration_ms{conclusion="success",head_branch="smartlyio",head_sha="cd1a6551686e49aebe881d856be7c3e1f9fdb305",id="6666094182",name="Upload Release Asset",node_id="CR_kwDOHa4RRM8AAAABjVSGZg",repo="smartlyio/github-actions-exporter",run_id="2413350926",status="completed",workflow="Build",workflow_id="27134893"} 49000
```